### PR TITLE
Improve Conclusions Help/Documentation #452

### DIFF
--- a/assets/app/js/controllers/conclusionDialog.js
+++ b/assets/app/js/controllers/conclusionDialog.js
@@ -204,7 +204,12 @@ class ConclusionDialog extends Controller {
           data: $.unique(license_expressions),
           multiple: true,
           placeholder: 'Enter Expression',
-          tags: true
+          tags: true,
+          language: {
+            'noResults': function () {
+              return ("SCWB did not find any license expressions in the scan that applies to the current path");
+            }
+          }
         }, true);
         this.license_expression.val(saved);
       });
@@ -221,7 +226,12 @@ class ConclusionDialog extends Controller {
           data: $.unique(copyright_statements),
           multiple: true,
           placeholder: 'Enter copyright',
-          tags: true
+          tags: true,
+          language: {
+            'noResults': function () {
+              return ("SCWB did not find any copyright statements in the scan pertaining to the current path");
+            }
+          }
         }, true);
         this.copyright.val(saved);
       });
@@ -237,7 +247,12 @@ class ConclusionDialog extends Controller {
           multiple: true,
           maximumSelectionLength: 1,
           placeholder: 'Enter owner',
-          tags: true
+          tags: true,
+          language: {
+            'noResults': function () {
+              return ("SCWB did not find any owners in the scan for the current path");
+            }
+          }
         }, true);
         this.owner.val(saved);
       });
@@ -254,7 +269,12 @@ class ConclusionDialog extends Controller {
           multiple: true,
           maximumSelectionLength: 1,
           placeholder: 'Enter language',
-          tags: true
+          tags: true,
+          language: {
+            'noResults': function () {
+              return ("SCWB did not find any primary programming languages in the scan associated with the current path");
+            }
+          }
         }, true);
         this.language.val(saved);
       });
@@ -283,7 +303,12 @@ class ConclusionDialog extends Controller {
           multiple: true,
           maximumSelectionLength: 1,
           placeholder: 'Enter Homepage URL',
-          tags: true
+          tags: true,
+          language: {
+            'noResults': function () {
+              return ("SCWB did not find any Homepage URL in the scan for the current path");
+            }
+          }
         }, true);
         this.homepageUrl.val(saved);
       });
@@ -303,7 +328,12 @@ class ConclusionDialog extends Controller {
           multiple: true,
           maximumSelectionLength: 1,
           placeholder: 'Enter Download URL',
-          tags: true
+          tags: true,
+          language: {
+            'noResults': function () {
+              return ("SCWB did not find any download URL in the scan for obtaining the current path");
+            }
+          }
         }, true);
         this.downloadUrl.val(saved);
       });
@@ -325,7 +355,12 @@ class ConclusionDialog extends Controller {
           multiple: true,
           maximumSelectionLength: 1,
           placeholder: 'Enter License URL',
-          tags: true
+          tags: true,
+          language: {
+            'noResults': function () {
+              return ("SCWB did not find any License url in the scan for the current path");
+            }
+          }
         }, true);
         this.licenseUrl.val(saved);
       });
@@ -341,7 +376,12 @@ class ConclusionDialog extends Controller {
           multiple: true,
           maximumSelectionLength: 1,
           placeholder: 'Enter Notice URL',
-          tags: true
+          tags: true,
+          language: {
+            'noResults': function () {
+              return ("SCWB did not find any Notice URL in the scan for the current path");
+            }
+          }
         }, true);
         this.noticeUrl.val(saved);
       });

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -27,7 +27,8 @@ ScanCode Workbench-ScanCode Toolkit Compatibility
       documentation:
       :doc:`scancode-toolkit:tutorials/how_to_set_what_will_be_detected_in_a_scan`.
 
-- You would typically create your scan with the following command: ``./scancode -clipeu <input> <output_file>``
+- You would typically create your scan with the following command:
+  ``./scancode -clipeu <input> <output_file>``
 
 Open ScanCode Workbench and Load a ScanCode Toolkit Scan
 ========================================================

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
@@ -394,15 +394,15 @@
                             <input type="text" class="form-control" id="conclusion-version" name="conclusion-version" placeholder="Enter version">
                         </fieldset>
                         <fieldset class="form-group">
-                            <label for="conclusion-license-expression" data-toggle="tooltip" data-placement="top" title="The license expression that applies to a conclusion.">License Expression</label>
+                            <label for="conclusion-license-expression" data-toggle="tooltip" data-placement="top" title="The license expression that applies to a conclusion. SCWB will present possible values from the scan.">License Expression<i class="fa fa-check-circle" aria-hidden="true" title="scan-based"></i></label>
                             <select data-hide-on-select="true" class="form-control " id="conclusion-license-expression" name="conclusion-license-expression" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
-                            <label for="conclusion-owner" data-toggle="tooltip" data-placement="top" title="The unique user-maintained name of the author, custodian, or provider of one or more software objects (licenses, products).">Owner</label>
+                            <label for="conclusion-owner" data-toggle="tooltip" data-placement="top" title="The unique user-maintained name of the author, custodian, or provider of one or more software objects (licenses, products). SCWB will present possible values from the scan.">Owner<i class="fa fa-check-circle" aria-hidden="true" title="scan-based"></i></label>
                             <select data-hide-on-select="true" class="form-control" id="conclusion-owner" name="conclusion-owner" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
-                            <label for="conclusion-copyright" data-toggle="tooltip" data-placement="top" title="The copyright statement(s) that pertain to this conclusion, as contained in the source or as specified in an associated file.">Copyright</label>
+                            <label for="conclusion-copyright" data-toggle="tooltip" data-placement="top" title="The copyright statement(s) that pertain to this conclusion, as contained in the source or as specified in an associated file. SCWB will present possible values from the scan.">Copyright<i class="fa fa-check-circle" aria-hidden="true" title="scan-based"></i></label>
                             <select data-hide-on-select="true" class="form-control" id="conclusion-copyright" name="conclusion-copyright" type="text"></select>
                         </fieldset>
                         <fieldset>
@@ -444,23 +444,23 @@
                             <input type="text" class="form-control" id="conclusion-purpose" name="conclusion-purpose" placeholder="Enter purpose">
                         </fieldset>
                         <fieldset class="form-group">
-                            <label for="conclusion-language" data-toggle="tooltip" data-placement="top" title="The primary programming language associated with the conclusion.">Programming Language</label>
+                            <label for="conclusion-language" data-toggle="tooltip" data-placement="top" title="The primary programming language associated with the conclusion. SCWB will present possible values from the scan.">Programming Language<i class="fa fa-check-circle" aria-hidden="true" title="scan-based"></i></label>
                             <select data-hide-on-select="true" class="form-control" id="conclusion-language" name="conclusion-language" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
-                            <label for="conclusion-homepage-url" data-toggle="tooltip" data-placement="top" title="Homepage URL for the conclusion.">Homepage URL</label>
+                            <label for="conclusion-homepage-url" data-toggle="tooltip" data-placement="top" title="Homepage URL for the conclusion. SCWB will present possible values from the scan.">Homepage URL<i class="fa fa-check-circle" aria-hidden="true" title="scan-based"></i></label>
                             <select data-hide-on-select="true" class="form-control" id="conclusion-homepage-url" name="conclusion-homepage-url" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
-                            <label for="conclusion-download-url" data-toggle="tooltip" data-placement="top" title="The download URL for obtaining the package.">Download URL</label>
+                            <label for="conclusion-download-url" data-toggle="tooltip" data-placement="top" title="The download URL for obtaining the package. SCWB will present possible values from the scan.">Download URL<i class="fa fa-check-circle" aria-hidden="true" title="scan-based"></i></label>
                             <select data-hide-on-select="true" class="form-control" id="conclusion-download-url" name="conclusion-download-url" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
-                            <label for="conclusion-license-url" data-toggle="tooltip" data-placement="top" title="Where available, the URL to the license text.">License URL</label>
+                            <label for="conclusion-license-url" data-toggle="tooltip" data-placement="top" title="Where available, the URL to the license text. SCWB will present possible values from the scan.">License URL<i class="fa fa-check-circle" aria-hidden="true" title="scan-based"></i></label>
                             <select data-hide-on-select="true" class="form-control" id="conclusion-license-url" name="conclusion-license-url" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
-                            <label for="conclusion-notice-url" data-toggle="tooltip" data-placement="top" title="A URL that contains notice text for a conclusion.">Notice URL</label>
+                            <label for="conclusion-notice-url" data-toggle="tooltip" data-placement="top" title="A URL that contains notice text for a conclusion. SCWB will present possible values from the scan.">Notice URL<i class="fa fa-check-circle" aria-hidden="true" title="scan-based"></i></label>
                             <select data-hide-on-select="true" class="form-control" id="conclusion-notice-url" name="conclusion-notice-url" type="text"></select>
                         </fieldset>
                     </form>

--- a/main.js
+++ b/main.js
@@ -233,7 +233,7 @@ function getTemplate() {
           type: 'separator'
         },
         {
-          label: 'GitHub Repoistory',
+          label: 'GitHub Repository',
           click: () => shell.openExternal(
             'https://github.com/nexB/scancode-workbench/')
         },


### PR DESCRIPTION
solved : #452 
- In edit conclusions modal
   - I have edited the help text of all scan based fields and added an icon for them
     ![Screenshot 2020-12-23 200003](https://user-images.githubusercontent.com/62306638/103009730-3d70a680-455d-11eb-91b3-8a63b78a2d93.png)

   - If the scan does not have any value for a particular field , the following text will be displayed. This is a result of the changes in assets/app/js/controllers/conclusionDialog.js
     ![Screenshot 2020-12-23 200116](https://user-images.githubusercontent.com/62306638/103009912-7ad53400-455d-11eb-96c1-69e0e3f2b940.png)
Is there anything else that I can add or change?