### PR TITLE
Automatic height for table

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,5 @@
 # Virtual environment
-.venv/
+venv/
 
 # sphinx build folder
 build/

--- a/src/components/FileTree/FileTree.tsx
+++ b/src/components/FileTree/FileTree.tsx
@@ -55,6 +55,7 @@ const FileTree = (props: React.HTMLProps<HTMLDivElement>) => {
     if (alreadyRenderedTargetNode) {
       // Immediate scroll possible
       scrollTreeNode(alreadyRenderedTargetNode);
+      endProcessing();
     } else {
       // Wait for target node to render
       pendingScrollerTimeoutId = setTimeout(() => {

--- a/src/components/LicenseEntity/LicenseEntity.tsx
+++ b/src/components/LicenseEntity/LicenseEntity.tsx
@@ -129,6 +129,7 @@ const LicenseEntity = (props: LicenseDetectionEntityProps) => {
         onGridSizeChanged={(params) => params.api.sizeColumnsToFit()}
         className="ag-theme-alpine ag-grid-customClass entity-table"
         ensureDomOrder
+        suppressHorizontalScroll
         enableCellTextSelection
         pagination={false}
         defaultColDef={DEFAULT_FILE_REGION_COL_DEF}

--- a/src/components/LicenseEntity/LicenseEntity.tsx
+++ b/src/components/LicenseEntity/LicenseEntity.tsx
@@ -112,7 +112,7 @@ const LicenseEntity = (props: LicenseDetectionEntityProps) => {
               : LicenseClueMatchCols
           }
           onGridReady={(params) => setMatchesTableColumnApi(params.columnApi)}
-          className="ag-theme-alpine ag-grid-customClass license-entity-table"
+          className="ag-theme-alpine ag-grid-customClass entity-table"
           ensureDomOrder
           enableCellTextSelection
           pagination={false}
@@ -127,20 +127,22 @@ const LicenseEntity = (props: LicenseDetectionEntityProps) => {
         columnDefs={DetectionFileRegionCols}
         onGridReady={(params) => params.api.sizeColumnsToFit()}
         onGridSizeChanged={(params) => params.api.sizeColumnsToFit()}
-        className="ag-theme-alpine ag-grid-customClass license-entity-table"
+        className="ag-theme-alpine ag-grid-customClass entity-table"
         ensureDomOrder
         enableCellTextSelection
         pagination={false}
         defaultColDef={DEFAULT_FILE_REGION_COL_DEF}
       />
       <br />
-      Raw license {activeLicenseEntity.type}
-      <ReactJson
-        src={activeLicenseEntity.license}
-        enableClipboard={false}
-        displayDataTypes={false}
-        collapsed={0}
-      />
+      <div className="raw-info-section">
+        Raw license {activeLicenseEntity.type}
+        <ReactJson
+          src={activeLicenseEntity.license}
+          enableClipboard={false}
+          displayDataTypes={false}
+          collapsed={0}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/LicenseEntity/LicenseEntity.tsx
+++ b/src/components/LicenseEntity/LicenseEntity.tsx
@@ -112,7 +112,7 @@ const LicenseEntity = (props: LicenseDetectionEntityProps) => {
               : LicenseClueMatchCols
           }
           onGridReady={(params) => setMatchesTableColumnApi(params.columnApi)}
-          className="ag-theme-alpine ag-grid-customClass matches-table"
+          className="ag-theme-alpine ag-grid-customClass license-entity-table"
           ensureDomOrder
           enableCellTextSelection
           pagination={false}
@@ -120,13 +120,14 @@ const LicenseEntity = (props: LicenseDetectionEntityProps) => {
         />
       </MatchedTextProvider>
       <br />
+      <br />
       File regions
       <AgGridReact
         rowData={file_regions}
         columnDefs={DetectionFileRegionCols}
         onGridReady={(params) => params.api.sizeColumnsToFit()}
         onGridSizeChanged={(params) => params.api.sizeColumnsToFit()}
-        className="ag-theme-alpine ag-grid-customClass file-regions-table"
+        className="ag-theme-alpine ag-grid-customClass license-entity-table"
         ensureDomOrder
         enableCellTextSelection
         pagination={false}

--- a/src/components/LicenseEntity/MatchedTextContext.tsx
+++ b/src/components/LicenseEntity/MatchedTextContext.tsx
@@ -12,6 +12,8 @@ import {
 import { ScanOptionKeys } from "../../utils/parsers";
 import { SYNTHETIC_RULE_PREFIXES } from "../../constants/licenseRules";
 
+import "./matchedText.css";
+
 interface MatchedTextContextProperties {
   showDiffWindow: boolean;
   openDiffWindow: (

--- a/src/components/LicenseEntity/licenseEntity.css
+++ b/src/components/LicenseEntity/licenseEntity.css
@@ -1,10 +1,3 @@
-:root {
-  --max-license-entity-table-height: 35vh;
-  --license-entity-table-header-height: 49px;
-  --license-entity-table-height: 5px;
-}
-
-
 .license-detecion-entity {
   height: 100%;
 }
@@ -22,25 +15,3 @@
   margin-right: 5px;
 }
 
-
-.license-entity-table {
-  /* max-height: 250px; */
-  max-height: var(--max-license-entity-table-height);
-  height: auto !important;
-}
-
-.license-entity-table .ag-root-wrapper-body.ag-layout-normal {
-  flex: none;
-  height: auto;
-}
-
-.license-entity-table .ag-body-viewport {
-  height: auto;
-  /* Subtract height of horizontal scroll and header from table height */
-  max-height: calc(var(--max-license-entity-table-height) - var(--license-entity-table-header-height) - var(--license-entity-table-height));
-  flex: none;
-}
-
-.license-entity-table .ag-center-cols-viewport {
-  height: auto;
-}

--- a/src/components/LicenseEntity/licenseEntity.css
+++ b/src/components/LicenseEntity/licenseEntity.css
@@ -1,3 +1,10 @@
+:root {
+  --max-license-entity-table-height: 35vh;
+  --license-entity-table-header-height: 49px;
+  --license-entity-table-height: 5px;
+}
+
+
 .license-detecion-entity {
   height: 100%;
 }
@@ -15,73 +22,25 @@
   margin-right: 5px;
 }
 
-.matches-table,
-.file-regions-table {
-  max-height: 30vh;
+
+.license-entity-table {
+  /* max-height: 250px; */
+  max-height: var(--max-license-entity-table-height);
+  height: auto !important;
 }
 
-.matched-text-diff-modal {
-  overflow: auto;
-  max-height: calc(100vh - 120px);
+.license-entity-table .ag-root-wrapper-body.ag-layout-normal {
+  flex: none;
+  height: auto;
 }
 
-.matched-text-diff-modal .row {
-  padding: 5px;
+.license-entity-table .ag-body-viewport {
+  height: auto;
+  /* Subtract height of horizontal scroll and header from table height */
+  max-height: calc(var(--max-license-entity-table-height) - var(--license-entity-table-header-height) - var(--license-entity-table-height));
+  flex: none;
 }
 
-.matched-text-diff-modal .rule-text-section {
-  background-color: #f6feff;
-  padding: 0;
-}
-
-.matched-text-diff-modal .matched-text-section {
-  background-color: #f9fffc;
-  padding: 0;
-}
-
-.matched-text-diff-modal .diff-table {
-  table-layout: fixed;
-  width: 100%;
-}
-
-.matched-text-diff-modal .diff-table th {
-  padding: 15px;
-  padding-left: 10px;
-  font-weight: 500;
-  background-color: #fafbfc;
-}
-
-.matched-text-diff-modal .diff-line {
-  display: table-row-group;
-  margin: 0;
-  vertical-align: top;
-  white-space: pre;
-  overflow-wrap: anywhere;
-}
-
-.matched-text-diff-modal .line-number {
-  margin-right: 15px;
-  padding-left: 10px;
-  padding-right: 10px;
-  opacity: 0.9;
-}
-
-.matched-text-diff-modal .line-content {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.matched-text-diff-modal .diff-line .line-content .line-text {
-  margin: 0;
-  display: inline-block;
-  white-space: pre-wrap;
-  line-height: 20px;
-}
-
-.matched-text-diff-modal .diff-line .line-content .removed-snippet {
-  background-color: #fdb8c0;
-}
-
-.matched-text-diff-modal .diff-line .line-content .added-snippet {
-  background-color: #acf2bd;
+.license-entity-table .ag-center-cols-viewport {
+  height: auto;
 }

--- a/src/components/LicenseEntity/matchedText.css
+++ b/src/components/LicenseEntity/matchedText.css
@@ -1,0 +1,62 @@
+.matched-text-diff-modal .row {
+  padding: 5px;
+  max-height: calc(100vh - 20vh);
+  overflow: auto;
+}
+
+.matched-text-diff-modal .rule-text-section {
+  background-color: #f6feff;
+  padding: 0;
+}
+
+.matched-text-diff-modal .matched-text-section {
+  background-color: #f9fffc;
+  padding: 0;
+}
+
+.matched-text-diff-modal .diff-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.matched-text-diff-modal .diff-table th {
+  padding: 15px;
+  padding-left: 10px;
+  font-weight: 500;
+  background-color: #fafbfc;
+}
+
+.matched-text-diff-modal .diff-line {
+  display: table-row-group;
+  margin: 0;
+  vertical-align: top;
+  white-space: pre;
+  overflow-wrap: anywhere;
+}
+
+.matched-text-diff-modal .line-number {
+  margin-right: 15px;
+  padding-left: 10px;
+  padding-right: 10px;
+  opacity: 0.9;
+}
+
+.matched-text-diff-modal .line-content {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.matched-text-diff-modal .diff-line .line-content .line-text {
+  margin: 0;
+  display: inline-block;
+  white-space: pre-wrap;
+  line-height: 20px;
+}
+
+.matched-text-diff-modal .diff-line .line-content .removed-snippet {
+  background-color: #fdb8c0;
+}
+
+.matched-text-diff-modal .diff-line .line-content .added-snippet {
+  background-color: #acf2bd;
+}

--- a/src/components/PackagesEntityDetails/DependenciesTableCols.ts.ts
+++ b/src/components/PackagesEntityDetails/DependenciesTableCols.ts.ts
@@ -29,36 +29,36 @@ export const DependenciesTableCols: DepsColDef[] = [
   {
     headerName: "Scope",
     field: "scope",
-    width: 130,
+    width: 160,
   },
   {
     headerName: "Resolved",
     field: "is_resolved",
     cellRenderer: TickRenderer,
-    maxWidth: 95,
+    maxWidth: 92,
   },
   {
     headerName: "Runtime",
     field: "is_runtime",
     cellRenderer: TickRenderer,
-    maxWidth: 95,
+    maxWidth: 92,
   },
   {
     headerName: "Optional",
     field: "is_optional",
     cellRenderer: TickRenderer,
-    maxWidth: 95,
+    maxWidth: 92,
   },
   {
     headerName: "Data source ID",
     field: "datasource_id",
-    width: 130,
+    width: 165,
   },
   {
     headerName: "Data file",
     field: "datafile_path",
     cellRenderer: FilePathRenderer,
-    width: 200,
+    width: 400,
   },
   {
     headerName: "Extracted requirement",

--- a/src/components/PackagesEntityDetails/DependencyEntity.tsx
+++ b/src/components/PackagesEntityDetails/DependencyEntity.tsx
@@ -97,14 +97,15 @@ const DependencyEntity = (props: DependencyEntityProps) => {
           />
         </div>
       )}
-      <br />
-      Raw dependency:
-      <ReactJson
-        src={dependency || {}}
-        enableClipboard={false}
-        displayDataTypes={false}
-        collapsed={0}
-      />
+      <div className="raw-info-section">
+        Raw dependency:
+        <ReactJson
+          src={dependency || {}}
+          enableClipboard={false}
+          displayDataTypes={false}
+          collapsed={0}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/PackagesEntityDetails/PackageEntity.tsx
+++ b/src/components/PackagesEntityDetails/PackageEntity.tsx
@@ -122,24 +122,26 @@ const PackageEntity = (props: PackageEntityProps) => {
           ? "1 Dependency:"
           : `${activePackage.dependencies.length} Dependencies:`}
       </b>
-      <br />
-      <AgGridReact
-        rowData={activePackage.dependencies}
-        columnDefs={DependenciesTableCols}
-        className="ag-theme-alpine ag-grid-customClass dependencies-table"
-        pagination
-        ensureDomOrder
-        enableCellTextSelection
-        defaultColDef={DEFAULT_DEPENDENCIES_COL_DEF}
-      />
-      <br />
-      Raw package:
-      <ReactJson
-        src={activePackage}
-        enableClipboard={false}
-        displayDataTypes={false}
-        collapsed={0}
-      />
+      {activePackage.dependencies.length > 0 && (
+        <AgGridReact
+          rowData={activePackage.dependencies}
+          columnDefs={DependenciesTableCols}
+          className="ag-theme-alpine ag-grid-customClass entity-table dependencies-table"
+          pagination
+          ensureDomOrder
+          enableCellTextSelection
+          defaultColDef={DEFAULT_DEPENDENCIES_COL_DEF}
+        />
+      )}
+      <div className="raw-info-section">
+        Raw package:
+        <ReactJson
+          src={activePackage}
+          enableClipboard={false}
+          displayDataTypes={false}
+          collapsed={0}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/PackagesEntityDetails/PackageEntity.tsx
+++ b/src/components/PackagesEntityDetails/PackageEntity.tsx
@@ -18,11 +18,11 @@ import "../../styles/entityCommonStyles.css";
 import "./packageEntity.css";
 
 interface PackageEntityProps {
-  package: PackageDetails;
+  activePackage: PackageDetails;
   goToDependency: (dependency: DependencyDetails) => void;
 }
 const PackageEntity = (props: PackageEntityProps) => {
-  const { package: activePackage } = props;
+  const { activePackage } = props;
   const { goToFileInTableView } = useWorkbenchDB();
 
   if (!activePackage) {

--- a/src/components/PackagesEntityDetails/packageEntity.css
+++ b/src/components/PackagesEntityDetails/packageEntity.css
@@ -4,4 +4,5 @@
 
 .dependencies-table {
   max-height: 40vh;
+  margin-bottom: 22px;
 }

--- a/src/pages/DependencyInfoDash/DependencyInfoDash.tsx
+++ b/src/pages/DependencyInfoDash/DependencyInfoDash.tsx
@@ -60,7 +60,7 @@ const DependencyInfoDash = () => {
     >();
     packagesData.forEach((packageData) => {
       // Package data having PURL as null are invalid & will have no dependency
-      // Hence, don't consider such package data (will be fixed in further toolkit version)
+      // Hence, don't consider such package data (will be fixed in further scancode-toolkit version)
       if (!packageData.getDataValue("purl")) return;
 
       const packageDataType = packageData.getDataValue("type");
@@ -94,11 +94,15 @@ const DependencyInfoDash = () => {
       }, 0);
     });
 
-    return Array.from(packageTypeToSummaryMapping.values()).sort(
-      (packageTypeSummary1, packageTypeSummary2) =>
-        packageTypeSummary2.packageTypeDetails.total -
-        packageTypeSummary1.packageTypeDetails.total
-    );
+    return Array.from(packageTypeToSummaryMapping.values())
+      .filter(
+        (packageTypeSummary) => packageTypeSummary.packageTypeDetails.total > 0
+      )
+      .sort(
+        (packageTypeSummary1, packageTypeSummary2) =>
+          packageTypeSummary2.packageTypeDetails.total -
+          packageTypeSummary1.packageTypeDetails.total
+      );
   }
 
   useEffect(() => {
@@ -217,17 +221,22 @@ const DependencyInfoDash = () => {
         </Col>
       </Row>
       <br />
-      Dependency Scope summary by Package Type
-      <AgGridReact
-        rowData={Object.values(packageTypeSummaryData || {})}
-        columnDefs={DependencySummaryTableCols}
-        defaultColDef={DEFAULT_DEPS_SUMMARY_COL_DEF}
-        ensureDomOrder
-        enableCellTextSelection
-        onGridReady={(params) => params.api.sizeColumnsToFit()}
-        onGridSizeChanged={(params) => params.api.sizeColumnsToFit()}
-        className="ag-theme-alpine ag-grid-customClass scope-summary-table"
-      />
+      {packageTypeSummaryData.length > 0 && (
+        <>
+        <h6>Dependency Scope summary by Package Type</h6>
+          <AgGridReact
+            rowData={Object.values(packageTypeSummaryData || {})}
+            columnDefs={DependencySummaryTableCols}
+            defaultColDef={DEFAULT_DEPS_SUMMARY_COL_DEF}
+            ensureDomOrder
+            enableCellTextSelection
+            suppressHorizontalScroll
+            onGridReady={(params) => params.api.sizeColumnsToFit()}
+            onGridSizeChanged={(params) => params.api.sizeColumnsToFit()}
+            className="ag-theme-alpine ag-grid-customClass scope-summary-table"
+          />
+        </>
+      )}
       <br />
       <Row className="dash-cards">
         <Col sm={4}>

--- a/src/pages/DependencyInfoDash/dependencyInfoDash.css
+++ b/src/pages/DependencyInfoDash/dependencyInfoDash.css
@@ -1,7 +1,38 @@
-.scope-summary-table {
-  max-height: 42vh;
+:root {
+  --min-scope-summary-table-height: 100px;
+  --max-scope-summary-table-height: 40vh;
+  --scope-summary-table-header-height: 49px;
+  --scope-summary-table-height: 5px;
 }
 
 .deps-status-flag-table .ag-header-cell-label {
   justify-content: center;
+}
+
+.scope-summary-table {
+  max-height: var(--max-scope-summary-table-height);
+  min-height: var(--min-scope-summary-table-height);
+  height: auto !important;
+}
+.scope-summary-table .ag-overlay-wrapper {
+  max-height: var(--max-scope-summary-table-height);
+  align-items: flex-end;
+  padding-bottom: 3%;
+}
+
+.scope-summary-table .ag-root-wrapper-body.ag-layout-normal {
+  flex: none;
+  height: auto;
+}
+
+.scope-summary-table .ag-body-viewport {
+  height: auto;
+  /* Subtract height of horizontal scroll and header from table height */
+  max-height: calc(var(--max-scope-summary-table-height) - var(--scope-summary-table-header-height) - var(--scope-summary-table-height));
+  min-height: calc(var(--min-scope-summary-table-height) - var(--scope-summary-table-header-height) - var(--scope-summary-table-height));
+  flex: none;
+}
+
+.scope-summary-table .ag-center-cols-viewport {
+  height: auto;
 }

--- a/src/pages/DependencyInfoDash/dependencyInfoDash.css
+++ b/src/pages/DependencyInfoDash/dependencyInfoDash.css
@@ -1,5 +1,5 @@
 :root {
-  --min-scope-summary-table-height: 100px;
+  --min-scope-summary-table-height: 90px;
   --max-scope-summary-table-height: 40vh;
   --scope-summary-table-header-height: 49px;
   --scope-summary-table-height: 5px;
@@ -14,6 +14,7 @@
   min-height: var(--min-scope-summary-table-height);
   height: auto !important;
 }
+
 .scope-summary-table .ag-overlay-wrapper {
   max-height: var(--max-scope-summary-table-height);
   align-items: flex-end;

--- a/src/pages/Packages/Packages.tsx
+++ b/src/pages/Packages/Packages.tsx
@@ -589,7 +589,7 @@ const Packages = () => {
           {activeEntityType ? (
             activeEntityType === "package" && activePackage ? (
               <PackageEntity
-                package={activePackage}
+                activePackage={activePackage}
                 goToDependency={activateDependency}
               />
             ) : activeEntityType === "dependency" && activeDependency ? (

--- a/src/pages/TableView/AgDataTable.tsx
+++ b/src/pages/TableView/AgDataTable.tsx
@@ -1,14 +1,11 @@
-import React, { useEffect } from 'react'
-import { AgGridReact, AgGridReactProps } from 'ag-grid-react';
-import {
-  ColDef,
-  GridApi,
-} from 'ag-grid-community';
+import React, { useEffect } from "react";
+import { AgGridReact, AgGridReactProps } from "ag-grid-react";
+import { ColDef, GridApi } from "ag-grid-community";
 
-import { frameworkComponents } from './columnDefs';
+import { frameworkComponents } from "./columnDefs";
 
-import 'ag-grid-community/styles/ag-grid.css';
-import 'ag-grid-community/styles/ag-theme-alpine.css';
+import "ag-grid-community/styles/ag-grid.css";
+import "ag-grid-community/styles/ag-theme-alpine.css";
 
 // Config for Ag DataTable
 const defaultColDef: ColDef = {
@@ -22,40 +19,35 @@ const defaultColDef: ColDef = {
 const paginationOptions = [25, 50, 100, 200];
 const defaultPaginationOption = paginationOptions[0];
 
-
 interface AgDataTableProps extends AgGridReactProps {
-  tableData: unknown[],
-  columnDefs: ColDef[],
-  gridApi: GridApi | null,
+  tableData: unknown[];
+  columnDefs: ColDef[];
+  gridApi: GridApi | null;
 }
 
 const AgDataTable = (props: AgDataTableProps) => {
-  const {
-    tableData, columnDefs, gridApi,
-  } = props;
-
+  const { tableData, columnDefs, gridApi } = props;
 
   const changePaginationSize = (newValue: string | number) => {
-    if(gridApi){
+    if (gridApi) {
       gridApi.paginationSetPageSize(Number(newValue));
     }
-  }
+  };
 
   useEffect(() => {
-    if(gridApi){
+    if (gridApi) {
       gridApi.setFilterModel(null);
 
       // Setting column defs manually to lazily update columns
       gridApi.setColumnDefs(columnDefs);
     }
-  }, [columnDefs])
-
+  }, [columnDefs]);
 
   return (
     <div
       style={{
-        height: 'calc(90vh - 50px)',
-        width: '100%',
+        height: "calc(90vh - 50px)",
+        width: "100%",
       }}
     >
       <AgGridReact
@@ -64,18 +56,15 @@ const AgDataTable = (props: AgDataTableProps) => {
         className="ag-theme-alpine ag-grid-customClass"
         ensureDomOrder
         enableCellTextSelection
-
         pagination={true}
         defaultColDef={defaultColDef}
         paginationPageSize={defaultPaginationOption}
-
         // Performance options
         rowBuffer={200}
         animateRows={false}
         suppressColumnMoveAnimation
         suppressRowVirtualisation
         suppressColumnVirtualisation
-
         {...props}
       />
 
@@ -83,19 +72,17 @@ const AgDataTable = (props: AgDataTableProps) => {
         Page Size:
         <select
           defaultValue={defaultPaginationOption}
-          onChange={e => changePaginationSize(e.target.value)}
+          onChange={(e) => changePaginationSize(e.target.value)}
         >
-          {
-            paginationOptions.map(optionValue => (
-              <option value={optionValue} key={optionValue}>
-                { optionValue }
-              </option>
-            ))
-          }
+          {paginationOptions.map((optionValue) => (
+            <option value={optionValue} key={optionValue}>
+              {optionValue}
+            </option>
+          ))}
         </select>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default AgDataTable
+export default AgDataTable;

--- a/src/pages/TableView/TableView.css
+++ b/src/pages/TableView/TableView.css
@@ -1,8 +1,9 @@
-.globalSearch{
+.globalSearch {
   display: inline-flex;
   float: right;
   margin-right: 15px;
 }
+
 .globalSearch input {
   display: inline-block;
 }
@@ -10,17 +11,19 @@
 .filterButtons {
   margin-bottom: 4px;
 }
-.filterButtons section{
+
+.filterButtons section {
   display: inline-flex;
   margin-left: 10px;
   margin-right: 10px;
 }
-.filterButtons button{
+
+.filterButtons button {
   margin: 3px;
   margin-right: 10px;
 }
 
-.column-selector{
+.column-selector {
   padding: 15px;
 }
 
@@ -30,23 +33,33 @@
   margin-right: 0px;
   font-size: 15px;
 }
-.pagination-controls select{
+
+.pagination-controls select {
   margin-left: 10px;
+}
+
+.matches-table {
+  max-height: 250px;
+  height: auto;
 }
 
 .ag-grid-customClass {
   font-size: 12px !important;
   --ag-cell-horizontal-border: 1px solid rgb(225 225 225) !important;
 }
+
+
 .ag-cell-wrapper {
   padding: 7px 0 10px 0;
   font-size: 14px;
   line-height: 1.5;
 }
+
 .ag-cell-wrapper .ag-cell-value {
   max-height: 300px;
   overflow-y: overlay;
 }
+
 .ag-cell-wrap-text {
   word-break: break-word;
 }

--- a/src/styles/entityCommonStyles.css
+++ b/src/styles/entityCommonStyles.css
@@ -1,3 +1,9 @@
+:root {
+  --max-entity-table-height: 35vh;
+  --entity-table-header-height: 49px;
+  --entity-table-height: 5px;
+}
+
 .entity-properties {
   font-size: 14px;
 }
@@ -16,5 +22,33 @@
 .license-detecion-entity .react-json-view {
   max-height: 75vh;
   overflow: auto;
-  margin-bottom: 15px;
+}
+
+.package-entity .raw-info-section,
+.dependency-entity .raw-info-section,
+.license-detecion-entity .raw-info-section {
+  margin-top: 15px;
+  margin-bottom: 25px;
+}
+
+.entity-table {
+  /* max-height: 250px; */
+  max-height: var(--max-entity-table-height);
+  height: auto !important;
+}
+
+.entity-table .ag-root-wrapper-body.ag-layout-normal {
+  flex: none;
+  height: auto;
+}
+
+.entity-table .ag-body-viewport {
+  height: auto;
+  /* Subtract height of horizontal scroll and header from table height */
+  max-height: calc(var(--max-entity-table-height) - var(--entity-table-header-height) - var(--entity-table-height));
+  flex: none;
+}
+
+.entity-table .ag-center-cols-viewport {
+  height: auto;
 }


### PR DESCRIPTION
Fixes #598 

Applies auto height for
* License explorer - Matches & File region tables
* Package explorer - Dependencies table
* Dependency Info dashboard - Dependency scope summary table

Not affecting Tableview, as its expected to be a full screen view