### PR TITLE
MacoOS arm builds on github actions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       # - name: Exit if tag not is not pointing to a commit in master branch
       #   if: endsWith(github.ref, 'master') == false
       #   run: exit -1
@@ -41,13 +41,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.12.0
       - uses: actions/setup-node@master
         with:
-          node-version: 16.13.0
+          node-version: 20
       - name: Install dependencies
         run: npm install
       - name: Create release assets directory

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -38,13 +38,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12.0
       - uses: actions/setup-node@master
         with:
           node-version: 16.13.0

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,15 +11,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@master
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
       - run: npm install
       - run: npm test

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.12.0]
 
     steps:
       - name: Checkout code

--- a/docs/source/contribute/building.rst
+++ b/docs/source/contribute/building.rst
@@ -29,18 +29,18 @@ Building Requirements
 Linux
 -----
 
-- `Python <https://www.python.org/>`__ v3.7 or later
-- `Node.js <https://nodejs.org/en//>`__ 14.x or later
-- `npm <https://www.npmjs.com/>`__ v6.14.4 or later
+- `Python <https://www.python.org/>`__ v3.9 or later
+- `Node.js <https://nodejs.org/en//>`__ 16.x or later
+- `npm <https://www.npmjs.com/>`__ v8.x or later
 
 .. include:: ../rst_snippets/centos-note.rst
 
 MacOS
 -----
 
-- `Python <https://www.python.org/>`__ v3.7 or later
-- `Node.js <https://nodejs.org/en/>`__ 14.x or later
-- `npm <https://www.npmjs.com/>`__ v6.14.4 or later
+- `Python <https://www.python.org/>`__ v3.9 or later
+- `Node.js <https://nodejs.org/en/>`__ 16.x or later
+- `npm <https://www.npmjs.com/>`__ v8.x or later
 - Command Line Tools for `Xcode <https://developer.apple.com/xcode/resources/>`_
    Install using:
 
@@ -51,7 +51,7 @@ MacOS
 Windows
 -------
 
-- `Python <https://www.python.org/>`__ v3.7 or later
+- `Python <https://www.python.org/>`__ v3.9 or later
 
   * Make sure your Python path is set. To verify, open a command prompt and see the python version:
 
@@ -59,8 +59,8 @@ Windows
 
       python --version
 
-- `Node.js <https://nodejs.org/en/>`__ v14.x or later
-- `npm <https://www.npmjs.com/>`__ v6.14.4 or later
+- `Node.js <https://nodejs.org/en/>`__ v16.x or later
+- `npm <https://www.npmjs.com/>`__ v8.x or later
 
 
 Release Instructions


### PR DESCRIPTION
Test release - https://github.com/OmkarPh/scancode-workbench/releases/tag/v4.0.1-arm64-build

- Included recently released m1 macos runners in github actions.
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

- Updated Node & python versions used in CI and docs

